### PR TITLE
Fixed bug and also using deepcopies

### DIFF
--- a/horizontal_flattening.py
+++ b/horizontal_flattening.py
@@ -30,7 +30,7 @@ class HorizonalFlattening():
                 del document[field]
                 for result in list(flatenned_results.keys()):
                     document[result] = flatenned_results[result]
-            if isinstance(document[field], list) and self.flatten_arrays_get_value() > 0:
+            elif isinstance(document[field], list) and self.flatten_arrays_get_value() > 0: #bug_7
                 flatenned_results = self.restructure_flatten_array(field, document[field], self.flatten_arrays_get_value())
                 for _ in range(0, self.flatten_arrays_get_value()):
                     del document[field][_]

--- a/test_horizontal_flattening.py
+++ b/test_horizontal_flattening.py
@@ -1,5 +1,6 @@
 import horizontal_flattening as hf
 import unittest
+import copy
 
 sample_document = {
  "_id" : "5780046cd5a397806c3dab38",
@@ -44,7 +45,8 @@ class TestCovid(unittest.TestCase):
         self.hf = hf.HorizonalFlattening()
 
     def test_horizontal_flat_simple(self):
-        assert self.hf.horizontal_flat(sample_document) == sample_document
+        sample_document_ = copy.deepcopy(sample_document)
+        assert self.hf.horizontal_flat(sample_document_) == sample_document
     
     def test_horizontal_flatten_object(self):
         self.hf.flatten_arrays_set_value(2)
@@ -63,6 +65,26 @@ class TestCovid(unittest.TestCase):
                                                             'restaurant_id': '30075445', 
                                                             'grades.0': {'date': '2014-03-03T00:00:00Z', 'grade': 'A', 'score': 2}, 
                                                             'grades.1': {'date': '2013-09-11T00:00:00Z', 'grade': 'A', 'score': 6}}
+
+    def test_horizontal_flatten_array(self):
+        self.hf.flatten_arrays_set_value(0)
+        self.hf.flatten_objects_set_value(True)
+        sample_document_ = copy.deepcopy(sample_document)
+        assert self.hf.horizontal_flat(sample_document_) == {'_id': '5780046cd5a397806c3dab38',
+                                                             'borough': 'Bronx', 
+                                                             'cuisine': 'Bakery', 
+                                                             'grades': [{'date': '2014-03-03T00:00:00Z', 'grade': 'A', 'score': 2}, 
+                                                                        {'date': '2013-09-11T00:00:00Z', 'grade': 'A', 'score': 6}, 
+                                                                        {'date': '2013-01-24T00:00:00Z', 'grade': 'A', 'score': 10}, 
+                                                                        {'date': '2011-11-23T00:00:00Z', 'grade': 'A', 'score': 9}, 
+                                                                        {'date': '2011-03-10T00:00:00Z', 'grade': 'B', 'score': 14}],
+                                                             'name': 'Morris Park Bake Shop',
+                                                              'restaurant_id': '30075445',
+                                                              'address.building': '1007',
+                                                              'address.coord': [-73.856077, 40.848447],
+                                                              'address.street': 'Morris Park Ave', 
+                                                              'address.zipcode': '10462'}
+
 
 
     


### PR DESCRIPTION
Two fixes done:

(1) Replaced if by elif because the fields get changed and since the key gets deleted, throws excecption
(2) In Unit testing, using copy.deepcopy() so that each test case takes one copy instead of making any change to the global variable itself.